### PR TITLE
Adds missing method typing

### DIFF
--- a/nativescript-contacts.d.ts
+++ b/nativescript-contacts.d.ts
@@ -65,6 +65,7 @@ declare module "nativescript-contacts" {
         urls: ContactField[];
 
         public save();
+        public delete();
     }
 
     export var KnownLabel: {


### PR DESCRIPTION
The `delete()` method was missing from the .d.ts file, added it so it can be used from within TypeScript.